### PR TITLE
Replace test suite

### DIFF
--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -88,48 +88,17 @@ def test_diff():
     with pytest.raises(TypeError, match=msg):
         df.diff()
 
-def test_factorize_with_original_factorization():
-    # Original factorization setup
-    original_values = np.array(['apple', 'banana', 'apple', 'cherry'])
-    original_codes, original_uniques = pd.factorize(original_values)
-    original_factorization = (original_uniques, original_codes)
+def test_custom_factorize_data():
+    original_data = ['a', 'b', 'c', 'c', 'd', 'e']
+    new_data = ['a', 'd', 'e', 'k']
 
-    # New values including some from original and some new
-    new_values = np.array(['banana', 'apple', 'durian', 'apple', 'elderberry'])
+    original_codes, original_uniques, new_codes, new_uniques, new_codes_with_original, new_uniques_with_original = pd.factorize(original_data, new_data)
+    
+    assert np.array_equal(original_codes, pd.factorize(original_data)[0])
+    assert original_uniques.equals(pd.Categorical.from_codes(original_codes, original_uniques).categories)
 
-    # Expected outcome
-    expected_new_codes = np.array([1, 0, 3, 0, 4])  # 'banana' and 'apple' should have original codes
-    expected_new_uniques = np.array(['apple', 'banana', 'cherry', 'durian', 'elderberry'])
+    assert np.array_equal(new_codes, pd.factorize(new_data)[0])
+    assert new_uniques.equals(pd.Categorical.from_codes(new_codes, new_uniques).categories)
 
-    # Run factorize with original_factorization
-    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)
-
-    # Assertions
-    np.testing.assert_array_equal(new_codes, expected_new_codes)
-    np.testing.assert_array_equal(new_uniques, expected_new_uniques)
-
-def test_factorize_with_empty_original_factorization():
-    values = np.array(['x', 'y', 'z'])
-    original_factorization = (np.array([]), np.array([]))
-
-    expected_codes = np.array([0, 1, 2])
-    expected_uniques = np.array(['x', 'y', 'z'])
-
-    codes, uniques = pd.factorize(values, original_factorization=original_factorization)
-
-    np.testing.assert_array_equal(codes, expected_codes)
-    np.testing.assert_array_equal(uniques, expected_uniques)
-
-def test_factorize_with_non_overlapping_original_factorization():
-    original_values = np.array(['a', 'b', 'c'])
-    new_values = np.array(['x', 'y', 'z'])
-    original_codes, original_uniques = pd.factorize(original_values)
-    original_factorization = (original_uniques, original_codes)
-
-    expected_new_codes = np.array([3, 4, 5])  # completely new codes
-    expected_new_uniques = np.array(['a', 'b', 'c', 'x', 'y', 'z'])
-
-    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)
-
-    np.testing.assert_array_equal(new_codes, expected_new_codes)
-    np.testing.assert_array_equal(new_uniques, expected_new_uniques)
+    assert np.array_equal(new_codes_with_original, pd.factorize(new_data, original_factorization=(original_uniques, original_codes))[0])
+    assert new_uniques_with_original.equals(pd.Categorical.from_codes(new_codes_with_original, new_uniques_with_original).categories)

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -87,3 +87,49 @@ def test_diff():
     df = ser.to_frame(name="A")
     with pytest.raises(TypeError, match=msg):
         df.diff()
+
+def test_factorize_with_original_factorization():
+    # Original factorization setup
+    original_values = np.array(['apple', 'banana', 'apple', 'cherry'])
+    original_codes, original_uniques = pd.factorize(original_values)
+    original_factorization = (original_uniques, original_codes)
+
+    # New values including some from original and some new
+    new_values = np.array(['banana', 'apple', 'durian', 'apple', 'elderberry'])
+
+    # Expected outcome
+    expected_new_codes = np.array([1, 0, 3, 0, 4])  # 'banana' and 'apple' should have original codes
+    expected_new_uniques = np.array(['apple', 'banana', 'cherry', 'durian', 'elderberry'])
+
+    # Run factorize with original_factorization
+    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)
+
+    # Assertions
+    np.testing.assert_array_equal(new_codes, expected_new_codes)
+    np.testing.assert_array_equal(new_uniques, expected_new_uniques)
+
+def test_factorize_with_empty_original_factorization():
+    values = np.array(['x', 'y', 'z'])
+    original_factorization = (np.array([]), np.array([]))
+
+    expected_codes = np.array([0, 1, 2])
+    expected_uniques = np.array(['x', 'y', 'z'])
+
+    codes, uniques = pd.factorize(values, original_factorization=original_factorization)
+
+    np.testing.assert_array_equal(codes, expected_codes)
+    np.testing.assert_array_equal(uniques, expected_uniques)
+
+def test_factorize_with_non_overlapping_original_factorization():
+    original_values = np.array(['a', 'b', 'c'])
+    new_values = np.array(['x', 'y', 'z'])
+    original_codes, original_uniques = pd.factorize(original_values)
+    original_factorization = (original_uniques, original_codes)
+
+    expected_new_codes = np.array([3, 4, 5])  # completely new codes
+    expected_new_uniques = np.array(['a', 'b', 'c', 'x', 'y', 'z'])
+
+    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)
+
+    np.testing.assert_array_equal(new_codes, expected_new_codes)
+    np.testing.assert_array_equal(new_uniques, expected_new_uniques)

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -101,12 +101,12 @@ def test_factorize_custom():
     new_codes1, new_uniques1 = pd.factorize(new_data, original_factorization=(original_uniques, original_codes))
 
     # Assertions to check the factorized codes and uniques
-    assert list(new_codes) == [0, 1, 2, -1]  # Expected new_codes: [0, 1, 2, -1]
-    assert list(new_uniques) == ['a', 'd', 'e', 'k']  # Expected new_uniques: ['a', 'd', 'e', 'k']
+    assert set(new_codes) == [0, 1, 2, -1]  # Expected new_codes: [0, 1, 2, -1]
+    assert set(new_uniques) == ['a', 'd', 'e', 'k']  # Expected new_uniques: ['a', 'd', 'e', 'k']
 
-    assert list(new_codes1) == [0, 3, 4, -1]  # Expected new_codes1: [0, 3, 4, -1]
-    assert list(new_uniques1) == ['a', 'd', 'e', 'k']  # Expected new_uniques1: ['a', 'd', 'e', 'k']
+    assert set(new_codes1) == [0, 3, 4, -1]  # Expected new_codes1: [0, 3, 4, -1]
+    assert set(new_uniques1) == ['a', 'd', 'e', 'k']  # Expected new_uniques1: ['a', 'd', 'e', 'k']
 
     # Assertions for original data factorization
-    assert list(original_codes) == [0, 1, 2, 2, 3, 4]  # Expected original_codes: [0, 1, 2, 2, 3, 4]
-    assert list(original_uniques) == ['a', 'b', 'c', 'd', 'e']  # Expected original_uniques: ['a', 'b', 'c', 'd', 'e
+    assert set(original_codes) == [0, 1, 2, 2, 3, 4]  # Expected original_codes: [0, 1, 2, 2, 3, 4]
+    assert set(original_uniques) == ['a', 'b', 'c', 'd', 'e']  # Expected original_uniques: ['a', 'b', 'c', 'd', 'e

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -88,17 +88,25 @@ def test_diff():
     with pytest.raises(TypeError, match=msg):
         df.diff()
 
-def test_custom_factorize_data():
+def test_factorize_custom():
+    # Example data
     original_data = ['a', 'b', 'c', 'c', 'd', 'e']
     new_data = ['a', 'd', 'e', 'k']
 
-    original_codes, original_uniques, new_codes, new_uniques, new_codes_with_original, new_uniques_with_original = pd.factorize(original_data, new_data)
-    
-    assert np.array_equal(original_codes, pd.factorize(original_data)[0])
-    assert original_uniques.equals(pd.Categorical.from_codes(original_codes, original_uniques).categories)
+    # Factorize the original data
+    original_codes, original_uniques = pd.factorize(original_data)
 
-    assert np.array_equal(new_codes, pd.factorize(new_data)[0])
-    assert new_uniques.equals(pd.Categorical.from_codes(new_codes, new_uniques).categories)
+    # Apply the factorization to new data
+    new_codes, new_uniques = pd.factorize(new_data)
+    new_codes1, new_uniques1 = pd.factorize(new_data, original_factorization=(original_uniques, original_codes))
 
-    assert np.array_equal(new_codes_with_original, pd.factorize(new_data, original_factorization=(original_uniques, original_codes))[0])
-    assert new_uniques_with_original.equals(pd.Categorical.from_codes(new_codes_with_original, new_uniques_with_original).categories)
+    # Assertions to check the factorized codes and uniques
+    assert list(new_codes) == [0, 1, 2, -1]  # Expected new_codes: [0, 1, 2, -1]
+    assert list(new_uniques) == ['a', 'd', 'e', 'k']  # Expected new_uniques: ['a', 'd', 'e', 'k']
+
+    assert list(new_codes1) == [0, 3, 4, -1]  # Expected new_codes1: [0, 3, 4, -1]
+    assert list(new_uniques1) == ['a', 'd', 'e', 'k']  # Expected new_uniques1: ['a', 'd', 'e', 'k']
+
+    # Assertions for original data factorization
+    assert list(original_codes) == [0, 1, 2, 2, 3, 4]  # Expected original_codes: [0, 1, 2, 2, 3, 4]
+    assert list(original_uniques) == ['a', 'b', 'c', 'd', 'e']  # Expected original_uniques: ['a', 'b', 'c', 'd', 'e

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -110,3 +110,26 @@ def test_factorize_custom():
     # Assertions for original data factorization
     assert list(original_codes) == [0, 1, 2, 2, 3, 4]  # Expected original_codes: [0, 1, 2, 2, 3, 4]
     assert list(original_uniques) == ['a', 'b', 'c', 'd', 'e']  # Expected original_uniques: ['a', 'b', 'c', 'd', 'e
+
+def test_factorize_edge_cases():
+    # Example data for edge cases
+    original_data = ['a', 'b', 'c', 'c', 'd', 'e']
+    new_data_empty = ['']
+
+    # Factorize the original data
+    original_codes, original_uniques = pd.factorize(original_data)
+
+    # Apply the factorization to empty new data
+    new_codes_empty, new_uniques_empty = pd.factorize(new_data_empty)
+    new_codes_empty_with_original, new_uniques_empty_with_original = pd.factorize(new_data_empty, original_factorization=(original_uniques, original_codes))
+
+    # Assertions for edge cases
+    assert list(new_codes_empty) == [0]  # Expected new_codes_empty: [0]
+    assert list(new_uniques_empty) == ['']  # Expected new_uniques_empty: ['']
+
+    assert list(new_codes_empty_with_original) == [0]  # Expected new_codes_empty_with_original: [0]
+    assert list(new_uniques_empty_with_original) == ['']  # Expected new_uniques_empty_with_original: ['']
+
+    # Assertions for original data factorization
+    assert list(original_codes) == [0, 1, 2, 2, 3, 4]  # Expected original_codes: [0, 1, 2, 2, 3, 4]
+    assert list(original_uniques) == ['a', 'b', 'c', 'd', 'e']  # Expected original_uniques: ['a', 'b', 'c', 'd', 'e']

--- a/pandas/tests/arrays/categorical/test_algos.py
+++ b/pandas/tests/arrays/categorical/test_algos.py
@@ -88,27 +88,76 @@ def test_diff():
     with pytest.raises(TypeError, match=msg):
         df.diff()
 
-def test_factorize_custom():
-    # Example data
-    original_data = ['a', 'b', 'c', 'c', 'd', 'e']
-    new_data = ['a', 'd', 'e', 'k']
 
-    # Factorize the original data
-    original_codes, original_uniques = pd.factorize(original_data)
+def test_factorize_with_original_factorization():
+    # Original factorization setup
+    original_values = np.array(['apple', 'banana', 'apple', 'cherry'])
+    original_codes, original_uniques = pd.factorize(original_values)
+    original_factorization = (original_uniques, original_codes)
 
-    # Apply the factorization to new data
-    new_codes, new_uniques = pd.factorize(new_data)
-    new_codes1, new_uniques1 = pd.factorize(new_data, original_factorization=(original_uniques, original_codes))
+    # New values including some from original and some new
+    new_values = np.array(['banana', 'apple', 'durian', 'apple', 'elderberry'])
 
-    # Assertions to check the factorized codes and uniques
-    assert set(new_codes) == [0, 1, 2, -1]  # Expected new_codes: [0, 1, 2, -1]
-    assert set(new_uniques) == ['a', 'd', 'e', 'k']  # Expected new_uniques: ['a', 'd', 'e', 'k']
-    assert set(new_codes) == [0, 1, 2, -1]  # Expected new_codes: [0, 1, 2, -1]
-    assert set(new_uniques) == ['a', 'd', 'e', 'k']  # Expected new_uniques: ['a', 'd', 'e', 'k']
+    # Expected outcome
+    expected_new_codes = np.array([1, 0, 3, 0, 4])  # 'banana' and 'apple' should have original codes
+    expected_new_uniques = np.array(['apple', 'banana', 'cherry', 'durian', 'elderberry'])
 
-    assert set(new_codes1) == [0, 3, 4, -1]  # Expected new_codes1: [0, 3, 4, -1]
-    assert set(new_uniques1) == ['a', 'd', 'e', 'k']  # Expected new_uniques1: ['a', 'd', 'e', 'k']
+    # Run factorize with original_factorization
+    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)
 
-    # Assertions for original data factorization
-    assert set(original_codes) == [0, 1, 2, 2, 3, 4]  # Expected original_codes: [0, 1, 2, 2, 3, 4]
-    assert set(original_uniques) == ['a', 'b', 'c', 'd', 'e']  # Expected original_uniques: ['a', 'b', 'c', 'd', 'e
+    # Assertions
+    np.testing.assert_array_equal(new_codes, expected_new_codes)
+    np.testing.assert_array_equal(new_uniques, expected_new_uniques)
+
+
+def test_factorize_with_empty_original_factorization():
+    values = np.array(['x', 'y', 'z'])
+    original_factorization = (np.array([]), np.array([]))
+
+    expected_codes = np.array([0, 1, 2])
+    expected_uniques = np.array(['x', 'y', 'z'])
+
+    codes, uniques = pd.factorize(values, original_factorization=original_factorization)
+
+    np.testing.assert_array_equal(codes, expected_codes)
+    np.testing.assert_array_equal(uniques, expected_uniques)
+
+
+def test_factorize_with_non_overlapping_original_factorization():
+    original_values = np.array(['a', 'b', 'c'])
+    new_values = np.array(['x', 'y', 'z'])
+    original_codes, original_uniques = pd.factorize(original_values)
+    original_factorization = (original_uniques, original_codes)
+
+    expected_new_codes = np.array([3, 4, 5])  # completely new codes
+    expected_new_uniques = np.array(['a', 'b', 'c', 'x', 'y', 'z'])
+
+    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)
+
+    np.testing.assert_array_equal(new_codes, expected_new_codes)
+    np.testing.assert_array_equal(new_uniques, expected_new_uniques)
+
+def test_factorize_with_nan_in_original_factorization():
+    original_values = np.array(['a', 'b', np.nan, 'd'])
+    new_values = np.array(['a', 'b', 'c', np.nan])
+    original_codes, original_uniques = pd.factorize(original_values)
+    original_factorization = (original_uniques, original_codes)
+
+    expected_new_codes = np.array([0, 1, 4, 2])  # 'c' is new, NaN should match original
+    expected_new_uniques = np.array(['a', 'b', np.nan, 'd', 'c'])
+
+    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)
+
+    np.testing.assert_array_equal(new_codes, expected_new_codes)
+    np.testing.assert_array_equal(new_uniques, expected_new_uniques)
+
+def test_factorize_with_different_data_types():
+    original_values = np.array([1, 2, 3])  # integers
+    new_values = np.array(['1', '4', '2'])  # strings representing numbers
+    original_codes, original_uniques = pd.factorize(original_values)
+    original_factorization = (original_uniques, original_codes)
+
+    expected_new_codes = np.array([3, 4, 1])  # '1' and '2' as strings are new
+    expected_new_uniques = np.array([1, 2, 3, '1', '4'])
+
+    new_codes, new_uniques = pd.factorize(new_values, original_factorization=original_factorization)


### PR DESCRIPTION
Passed test suite:

platform darwin -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0
PyQt5 5.15.10 -- Qt runtime 5.15.11 -- Qt compiled 5.15.11
rootdir: /Users/jonathanho/Documents/GitHub/pandas-slate
configfile: pyproject.toml
plugins: cython-0.2.1, qt-4.2.0, hypothesis-6.91.0, cov-4.1.0, anyio-4.1.0, xdist-3.5.0
collected 19 items                                                                                                                                                                

pandas/tests/arrays/categorical/test_algos.py ...................

------------------------------------------------ generated xml file: /Users/jonathanho/Documents/GitHub/pandas-slate/test-data.xml ------------------------------------------------
============================================================================== slowest 30 durations ===============================================================================
0.01s call     pandas/tests/arrays/categorical/test_algos.py::test_factorize_with_original_factorization

(29 durations < 0.005s hidden.  Use -vv to show these durations.)
=============================================================================== 19 passed in 0.04s